### PR TITLE
[Upstream] audio: set the proper ACDB IDs for the TMUS in & out sound devices

### DIFF
--- a/audio/audio_platform_info.xml
+++ b/audio/audio_platform_info.xml
@@ -41,6 +41,8 @@
         <device name="SND_DEVICE_IN_UNPROCESSED_QUAD_MIC" acdb_id="146"/>
         <device name="SND_DEVICE_IN_UNPROCESSED_HEADSET_MIC" acdb_id="147"/>
         <device name="SND_DEVICE_IN_VOICE_SPEAKER_DMIC" acdb_id="132"/>
+        <device name="SND_DEVICE_OUT_VOICE_HANDSET_TMUS" acdb_id="7"/>
+        <device name="SND_DEVICE_IN_VOICE_DMIC_TMUS" acdb_id="41"/>
     </acdb_ids>
     <bit_width_configs>
         <device name="SND_DEVICE_OUT_SPEAKER" bit_width="24"/>


### PR DESCRIPTION
> **mata: audio: set the proper ACDB IDs for the TMUS in & out sound devices**
> 
> Cherry-picked from upstream LineageOS: https://github.com/LineageOS/android_device_essential_mata/commit/8626a7ce265b25e3dc14043308d30df7c567fcdd
> 
> * Align the ADCB IDs of the TMUS sound devices with those of their non-TMUS counterparts.
> 
> * This fixes distorted in-call audio when VoLTE is enabled for users with T-Mobile SIM cards.
> 
> Change-Id: Ib74ed34b45331e5760a8de8ef500a3513c8b21a5

**Please note:** I have not personally tested these changes; I merely cherry-picked them from upstream. However, I _can_ confirm that VoLTE on T-Mobile produces distorted call audio on current builds of CarbonROM.